### PR TITLE
perf(ci): non-breaking docker-build perf & security

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -174,6 +174,11 @@ inputs:
     description: 'SLSA build provenance for the PUSHED image. Passed to docker/build-push-action (false, true, or mode=max). Default false preserves the current single-manifest form; enabling it attaches an attestation manifest (changes the observable manifest/index) - opt-in only.'
     required: false
     default: 'false'
+  # VEX (Vulnerability Exploitability eXchange)
+  generate-vex:
+    description: 'Generate an OpenVEX document from the Trivy scan report (all CVEs under_investigation, merged with optional security/vex-overrides.json). Requires security-scan=true with the trivy scanner. Default false.'
+    required: false
+    default: 'false'
   # Metadata & Labels
   add-git-labels:
     description: 'Add Git metadata as labels'
@@ -230,6 +235,9 @@ outputs:
   sbom-attested:
     description: 'Whether the SBOM was cryptographically attested (true/false)'
     value: ${{ steps.attest-sbom.outputs.attested }}
+  vex-path:
+    description: 'Path to the generated OpenVEX document (empty when generate-vex is false)'
+    value: ${{ steps.vex.outputs.vex-path }}
   build-duration:
     description: 'Build duration in seconds'
     value: ${{ steps.build-info.outputs.duration }}
@@ -814,6 +822,18 @@ runs:
         sbom-path: ${{ inputs.working-directory }}/${{ steps.sbom.outputs.path }}
         # Map the syft format (cyclonedx|spdx) to the attest action's expected value.
         sbom-format: ${{ inputs.sbom-format == 'spdx' && 'spdx-json' || 'cyclonedx-json' }}
+
+    - name: 📋 Generate OpenVEX Document
+      id: vex
+      # always(): document vulnerabilities even when the scan blocked the push (exit 1) -
+      # that is exactly when a VEX triage record is most useful. Requires the Trivy JSON
+      # report; a non-trivy scanner or missing report yields an empty VEX (handled inside).
+      if: always() && inputs.security-scan == 'true' && inputs.generate-vex == 'true' && steps.security.outputs.report-path != ''
+      uses: bauer-group/automation-templates/.github/actions/vex-generate@main
+      with:
+        vulnerability-report-path: ${{ inputs.working-directory }}/${{ steps.security.outputs.report-path }}
+        # Write into docker-build-reports so it rides the existing security-reports artifact.
+        output-file: ${{ inputs.working-directory }}/docker-build-reports/vex.openvex.json
 
     - name: 📤 Upload Security Reports
       if: always() && inputs.security-scan == 'true'

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -165,6 +165,15 @@ inputs:
     description: 'SBOM format (cyclonedx, spdx)'
     required: false
     default: 'cyclonedx'
+  attest-sbom:
+    description: 'Create a GitHub (Sigstore) attestation for the generated SBOM. Requires generate-sbom=true and the caller job to grant attestations:write + id-token:write. Default false = no attestation (current behaviour).'
+    required: false
+    default: 'false'
+  # Provenance
+  provenance:
+    description: 'SLSA build provenance for the PUSHED image. Passed to docker/build-push-action (false, true, or mode=max). Default false preserves the current single-manifest form; enabling it attaches an attestation manifest (changes the observable manifest/index) - opt-in only.'
+    required: false
+    default: 'false'
   # Metadata & Labels
   add-git-labels:
     description: 'Add Git metadata as labels'
@@ -218,6 +227,9 @@ outputs:
   sbom-path:
     description: 'Path to generated SBOM'
     value: ${{ steps.sbom.outputs.path }}
+  sbom-attested:
+    description: 'Whether the SBOM was cryptographically attested (true/false)'
+    value: ${{ steps.attest-sbom.outputs.attested }}
   build-duration:
     description: 'Build duration in seconds'
     value: ${{ steps.build-info.outputs.duration }}
@@ -695,7 +707,10 @@ runs:
         # from scratch under QEMU on every run.
         cache-from: ${{ steps.cache-settings.outputs.cache-from-push }}
         cache-to: ${{ steps.cache-settings.outputs.cache-to-push }}
-        provenance: false
+        # provenance: opt-in via the 'provenance' input (default 'false' = unchanged
+        # single-manifest push). Only the push build carries provenance - the local
+        # scan build uses load:true (docker exporter), which cannot hold attestations.
+        provenance: ${{ inputs.provenance }}
         sbom: false
 
     - name: 📊 Collect Build Information
@@ -786,6 +801,19 @@ runs:
         
         echo "path=$SBOM_PATH" >> $GITHUB_OUTPUT
         echo "📋 SBOM generated: $SBOM_PATH"
+
+    - name: 📜 Attest SBOM
+      id: attest-sbom
+      # Opt-in: only when an SBOM was generated AND attestation was requested. The
+      # sibling action wraps actions/attest-sbom (Sigstore); the caller job must grant
+      # attestations:write + id-token:write or the attestation step fails.
+      if: inputs.generate-sbom == 'true' && inputs.attest-sbom == 'true' && steps.sbom.outputs.path != ''
+      uses: bauer-group/automation-templates/.github/actions/sbom-attest@main
+      with:
+        # sbom step writes under working-directory; steps.sbom.outputs.path is relative to it.
+        sbom-path: ${{ inputs.working-directory }}/${{ steps.sbom.outputs.path }}
+        # Map the syft format (cyclonedx|spdx) to the attest action's expected value.
+        sbom-format: ${{ inputs.sbom-format == 'spdx' && 'spdx-json' || 'cyclonedx-json' }}
 
     - name: 📤 Upload Security Reports
       if: always() && inputs.security-scan == 'true'

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -245,6 +245,12 @@ runs:
         
         echo "✅ Docker build environment ready"
 
+    - name: 🔧 Set up QEMU
+      # Registers binfmt/QEMU so non-native arches (arm64, arm/v7) build reliably under
+      # emulation. Only needed for multi-platform builds; skipped otherwise (no-op cost).
+      if: inputs.multi-platform == 'true'
+      uses: docker/setup-qemu-action@v3
+
     - name: 🏗️ Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
       with:
@@ -501,16 +507,33 @@ runs:
 
         # Normalize to lowercase and check for truthy values
         if [[ "${CACHE_ENABLED,,}" == "true" || "${CACHE_ENABLED}" == "1" ]]; then
+          # Local (amd64 scan) build cache - unchanged, byte-identical for existing callers.
           echo "cache-from=type=gha${SCOPE_SUFFIX}" >> $GITHUB_OUTPUT
           echo "cache-to=type=gha${SCOPE_SUFFIX},mode=${{ inputs.cache-mode }}" >> $GITHUB_OUTPUT
+          # Push (multi-arch) build cache. Uses a DISTINCT '-push' scope so multi-arch
+          # layers - especially arm64, which is built ONLY in the push step - are exported
+          # and reused across runs. A shared scope cannot work: GHA cache keys are immutable,
+          # so the push export would 409 against the local build's manifest and arm64 would
+          # never be cached. cache-from reads BOTH scopes (amd64 from local, arm64 from a
+          # prior push run).
+          SCOPE_BASE="${CACHE_SCOPE:-buildkit}"
+          {
+            echo "cache-from-push<<CFPUSH"
+            echo "type=gha${SCOPE_SUFFIX}"
+            echo "type=gha,scope=${SCOPE_BASE}-push"
+            echo "CFPUSH"
+          } >> $GITHUB_OUTPUT
+          echo "cache-to-push=type=gha,scope=${SCOPE_BASE}-push,mode=${{ inputs.cache-mode }}" >> $GITHUB_OUTPUT
           if [ -n "$CACHE_SCOPE" ]; then
-            echo "📦 Build cache: ENABLED (mode=${{ inputs.cache-mode }}, scope=${CACHE_SCOPE})"
+            echo "📦 Build cache: ENABLED (mode=${{ inputs.cache-mode }}, scope=${CACHE_SCOPE}, push-scope=${SCOPE_BASE}-push)"
           else
-            echo "📦 Build cache: ENABLED (mode=${{ inputs.cache-mode }})"
+            echo "📦 Build cache: ENABLED (mode=${{ inputs.cache-mode }}, push-scope=${SCOPE_BASE}-push)"
           fi
         else
           echo "cache-from=" >> $GITHUB_OUTPUT
           echo "cache-to=" >> $GITHUB_OUTPUT
+          echo "cache-from-push=" >> $GITHUB_OUTPUT
+          echo "cache-to-push=" >> $GITHUB_OUTPUT
           echo "📦 Build cache: DISABLED"
         fi
 
@@ -667,8 +690,11 @@ runs:
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
         target: ${{ inputs.target }}
-        cache-from: ${{ steps.cache-settings.outputs.cache-from }}
-        # Note: cache-to is only used in local build step
+        # Multi-arch cache: read amd64 (from the local scan build) + arm64 (from a prior
+        # push run), and export everything to the '-push' scope so arm64 is not rebuilt
+        # from scratch under QEMU on every run.
+        cache-from: ${{ steps.cache-settings.outputs.cache-from-push }}
+        cache-to: ${{ steps.cache-settings.outputs.cache-to-push }}
         provenance: false
         sbom: false
 
@@ -770,7 +796,12 @@ runs:
         retention-days: 30
 
     - name: 📊 Upload Security Scan to GitHub Security
-      if: inputs.security-scan == 'true' && steps.security.outputs.sarif-path != ''
+      # always(): the scan step exit 1's when it blocks a push, but the SARIF file
+      # already exists and must still reach the Security tab (the case you most need it).
+      # continue-on-error: a reporting step must never fail the build (e.g. repos without
+      # code scanning / GHAS). Matches the fork-docker-build.yml behaviour.
+      if: always() && inputs.security-scan == 'true' && steps.security.outputs.sarif-path != ''
+      continue-on-error: true
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.working-directory }}/${{ steps.security.outputs.sarif-path }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -500,9 +500,10 @@ jobs:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          lfs: true
-      
+          # README sync only needs the working-tree README; skip full history + LFS blobs.
+          fetch-depth: 1
+          lfs: false
+
       - name: 📄 Determine README File
         id: readme
         shell: bash
@@ -619,7 +620,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🛡️ Run Advanced Security Analysis
-        if: inputs.security-scan == true
+        # Guard on image-pushed: this scans the *registry* image, which does not exist on
+        # PRs / push:false runs (previously failed the job red). continue-on-error keeps this
+        # informational job non-fatal so the deploy gate (needs.security-analysis) is stable.
+        if: inputs.security-scan == true && needs.build.outputs.image-pushed == 'true'
+        continue-on-error: true
         shell: bash
         run: |
           echo "🛡️ Running advanced security analysis..."
@@ -665,23 +670,16 @@ jobs:
   deploy:
     name: 🚀 Deploy Image
     needs: [build, security-analysis]
-    if: always() && needs.build.result == 'success' && needs.security-analysis.result == 'success'
+    # Only run (and spin up a runner) when deployment is enabled. Previously an idle runner
+    # started on every default run just to echo a "disabled" notice. summary tolerates the
+    # resulting 'skipped' result.
+    if: always() && inputs.deploy-enabled == true && needs.build.result == 'success' && needs.security-analysis.result == 'success'
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJSON(inputs.runs-on) || inputs.runs-on }}
     environment:
       name: ${{ inputs.deploy-environment }}
       url: ${{ steps.deploy.outputs.url }}
 
     steps:
-      - name: ⏭️ Deployment Disabled
-        if: inputs.deploy-enabled != true
-        run: |
-          echo "::notice title=Deployment Disabled::Deployment is disabled via inputs.deploy-enabled=false"
-          echo "## ⏭️ Deployment - Disabled" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Deployment is **disabled** in workflow configuration." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "To enable, set \`deploy-enabled: true\` in your workflow inputs." >> $GITHUB_STEP_SUMMARY
-
       - name: 📥 Checkout Repository
         if: inputs.deploy-enabled == true
         uses: actions/checkout@v6
@@ -740,6 +738,9 @@ jobs:
     needs: [build, dockerhub-readme, security-analysis, deploy]
     if: always()
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJSON(inputs.runs-on) || inputs.runs-on }}
+    timeout-minutes: 10 # Reporting only; caps 360-min default hang
+    permissions:
+      contents: read
 
     steps:
       - name: 📊 Generate Build Summary

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -198,12 +198,24 @@ on:
         type: boolean
         required: false
         default: false
-      
+
       sbom-format:
         description: 'SBOM format (cyclonedx, spdx)'
         type: string
         required: false
         default: 'cyclonedx'
+
+      attest-sbom:
+        description: 'Create a GitHub (Sigstore) attestation for the generated SBOM. Requires generate-sbom=true. Default false.'
+        type: boolean
+        required: false
+        default: false
+
+      provenance:
+        description: 'SLSA build provenance for the pushed image (false, true, or mode=max). Default false preserves the current single-manifest form; enabling it attaches an attestation manifest (opt-in).'
+        type: string
+        required: false
+        default: 'false'
       
       # Caching
       cache-enabled:
@@ -356,6 +368,14 @@ on:
         description: 'Security scan report path'
         value: ${{ jobs.build.outputs.security-report }}
 
+      sbom-path:
+        description: 'Path to the generated SBOM (empty when generate-sbom is false)'
+        value: ${{ jobs.build.outputs.sbom-path }}
+
+      sbom-attested:
+        description: 'Whether the SBOM was cryptographically attested (true/false)'
+        value: ${{ jobs.build.outputs.sbom-attested }}
+
       build-duration:
         description: 'Build duration in seconds'
         value: ${{ jobs.build.outputs.build-duration }}
@@ -365,6 +385,8 @@ permissions:
   contents: write        # For committing Dockerfile version updates
   packages: write        # For pushing to GHCR
   security-events: write # For uploading SARIF reports to GitHub Security
+  attestations: write    # For SBOM attestation (opt-in via attest-sbom; no effect otherwise)
+  id-token: write        # OIDC token required by Sigstore-based SBOM attestation
 
 jobs:
   build:
@@ -387,6 +409,8 @@ jobs:
       image-pushed: ${{ steps.docker-build.outputs.image-pushed }}
       security-scan-passed: ${{ steps.docker-build.outputs.security-scan-passed }}
       security-report: ${{ steps.docker-build.outputs.security-report }}
+      sbom-path: ${{ steps.docker-build.outputs.sbom-path }}
+      sbom-attested: ${{ steps.docker-build.outputs.sbom-attested }}
       build-duration: ${{ steps.docker-build.outputs.build-duration }}
     
     steps:
@@ -466,6 +490,8 @@ jobs:
           cosign-password: ${{ secrets.COSIGN_PASSWORD }}
           generate-sbom: ${{ inputs.generate-sbom }}
           sbom-format: ${{ inputs.sbom-format }}
+          attest-sbom: ${{ inputs.attest-sbom }}
+          provenance: ${{ inputs.provenance }}
           builder-driver: ${{ inputs.builder-driver }}
           build-timeout: ${{ inputs.build-timeout }}
           verbose-build-summary: ${{ inputs.verbose-build-summary }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -216,6 +216,12 @@ on:
         type: string
         required: false
         default: 'false'
+
+      generate-vex:
+        description: 'Generate an OpenVEX document from the Trivy scan report (requires security-scan=true with the trivy scanner). Default false.'
+        type: boolean
+        required: false
+        default: false
       
       # Caching
       cache-enabled:
@@ -376,6 +382,10 @@ on:
         description: 'Whether the SBOM was cryptographically attested (true/false)'
         value: ${{ jobs.build.outputs.sbom-attested }}
 
+      vex-path:
+        description: 'Path to the generated OpenVEX document (empty when generate-vex is false)'
+        value: ${{ jobs.build.outputs.vex-path }}
+
       build-duration:
         description: 'Build duration in seconds'
         value: ${{ jobs.build.outputs.build-duration }}
@@ -411,6 +421,7 @@ jobs:
       security-report: ${{ steps.docker-build.outputs.security-report }}
       sbom-path: ${{ steps.docker-build.outputs.sbom-path }}
       sbom-attested: ${{ steps.docker-build.outputs.sbom-attested }}
+      vex-path: ${{ steps.docker-build.outputs.vex-path }}
       build-duration: ${{ steps.docker-build.outputs.build-duration }}
     
     steps:
@@ -492,6 +503,7 @@ jobs:
           sbom-format: ${{ inputs.sbom-format }}
           attest-sbom: ${{ inputs.attest-sbom }}
           provenance: ${{ inputs.provenance }}
+          generate-vex: ${{ inputs.generate-vex }}
           builder-driver: ${{ inputs.builder-driver }}
           build-timeout: ${{ inputs.build-timeout }}
           verbose-build-summary: ${{ inputs.verbose-build-summary }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -647,84 +647,44 @@ jobs:
           echo ""
           echo "🔗 View on Docker Hub: https://hub.docker.com/r/${{ steps.docker-repo.outputs.repository }}"
 
-  # Image vulnerability analysis (separate job for comprehensive scanning)
+  # Image vulnerability analysis — delegated to the shared modules-vulnerability-scan
+  # workflow for unified SARIF categories + scoring (replaces the previous inline Trivy
+  # block). Runs only when scanning is enabled AND an image actually reached the registry
+  # (this pulls & scans the pushed image; nothing exists to scan on PRs / push:false).
+  # Skipped otherwise — deploy/summary tolerate the skipped result. Advisory only:
+  # fail-on-findings:false so it never blocks the build or the deploy gate.
+  # NOTE: the container scan (Anchore/Grype) pulls the image without a registry login, so
+  # for PRIVATE GHCR images this advisory job may report a pull failure. The build, tags,
+  # digests, outputs and deploy gate are unaffected.
   security-analysis:
     name: 🛡️ Advanced Security Analysis
     needs: build
-    if: always() && needs.build.result == 'success'
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJSON(inputs.runs-on) || inputs.runs-on }}
-    timeout-minutes: 15
-
-    steps:
-      - name: ⏭️ Security Scan Disabled
-        if: inputs.security-scan != true
-        run: |
-          echo "::notice title=Security Scan Disabled::Advanced security scanning is disabled via inputs.security-scan=false"
-          echo "## ⏭️ Advanced Security Scan - Disabled" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Advanced security scanning is **disabled** in workflow configuration." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "To enable, set \`security-scan: true\` in your workflow inputs." >> $GITHUB_STEP_SUMMARY
-
-      - name: 📥 Checkout Repository
-        if: inputs.security-scan == true
-        uses: actions/checkout@v6
-
-      - name: 🛡️ Run Advanced Security Analysis
-        # Guard on image-pushed: this scans the *registry* image, which does not exist on
-        # PRs / push:false runs (previously failed the job red). continue-on-error keeps this
-        # informational job non-fatal so the deploy gate (needs.security-analysis) is stable.
-        if: inputs.security-scan == true && needs.build.outputs.image-pushed == 'true'
-        continue-on-error: true
-        shell: bash
-        run: |
-          echo "🛡️ Running advanced security analysis..."
-
-          IMAGE_URL="${{ needs.build.outputs.image-url }}"
-
-          # Multiple scanner approach for comprehensive coverage
-          echo "Image: $IMAGE_URL"
-
-          # Install additional security tools
-          curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-
-          # Comprehensive Trivy scan
-          trivy image \
-            --format table \
-            --severity HIGH,CRITICAL \
-            "$IMAGE_URL"
-
-          # Check for secrets in image
-          trivy image \
-            --scanners secret \
-            --format table \
-            "$IMAGE_URL"
-
-          # Configuration scanning
-          trivy image \
-            --scanners config \
-            --format table \
-            "$IMAGE_URL"
-
-          echo "✅ Advanced security analysis completed"
-
-          # Add to summary
-          echo "## 🛡️ Advanced Security Analysis - Completed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Vulnerability Scan | ✅ Completed |" >> $GITHUB_STEP_SUMMARY
-          echo "| Secret Detection | ✅ Completed |" >> $GITHUB_STEP_SUMMARY
-          echo "| Config Analysis | ✅ Completed |" >> $GITHUB_STEP_SUMMARY
+    if: inputs.security-scan == true && needs.build.result == 'success' && needs.build.outputs.image-pushed == 'true'
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      actions: read
+    uses: bauer-group/automation-templates/.github/workflows/modules-vulnerability-scan.yml@main
+    with:
+      scan-engine: trivy
+      container-images: ${{ needs.build.outputs.image-url }}
+      container-severity: high
+      fail-on-findings: false
+      upload-sarif: true
+      runs-on: ${{ inputs.runs-on }}
+    secrets: inherit
 
   # Deployment job (if enabled)
   deploy:
     name: 🚀 Deploy Image
     needs: [build, security-analysis]
-    # Only run (and spin up a runner) when deployment is enabled. Previously an idle runner
-    # started on every default run just to echo a "disabled" notice. summary tolerates the
-    # resulting 'skipped' result.
-    if: always() && inputs.deploy-enabled == true && needs.build.result == 'success' && needs.security-analysis.result == 'success'
+    # Only run (and spin up a runner) when deployment is enabled AND the image was actually
+    # pushed. The advisory security-analysis job no longer gates deploy (it was previously
+    # continue-on-error, so it never truly gated); the real block is the in-build scan, which
+    # withholds the push (image-pushed=false) on failure. always() tolerates a skipped
+    # security-analysis (security-scan:false / PR builds).
+    if: always() && inputs.deploy-enabled == true && needs.build.result == 'success' && needs.build.outputs.image-pushed == 'true'
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJSON(inputs.runs-on) || inputs.runs-on }}
     environment:
       name: ${{ inputs.deploy-environment }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,20 @@ on:
         type: string
         required: false
         default: '.'
-      
+
+      # Checkout Configuration
+      checkout-fetch-depth:
+        description: 'Git history depth for the build checkout. 0 (default) fetches full history — required for Dockerfile-version write-back and semver tag derivation. Set 1 for a faster shallow checkout when neither is used.'
+        type: number
+        required: false
+        default: 0
+
+      checkout-lfs:
+        description: 'Fetch Git LFS objects on the build checkout. Default true preserves current behaviour (repos storing build assets in LFS). Set false to skip LFS blobs for a faster checkout.'
+        type: boolean
+        required: false
+        default: true
+
       dockerfile-path:
         description: 'Path to Dockerfile'
         type: string
@@ -380,9 +393,9 @@ jobs:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          lfs: true
-      
+          fetch-depth: ${{ inputs.checkout-fetch-depth }}
+          lfs: ${{ inputs.checkout-lfs }}
+
       - name: 🧪 Run Pre-Build Tests
         if: inputs.run-tests
         shell: bash

--- a/.github/workflows/fork-docker-build.yml
+++ b/.github/workflows/fork-docker-build.yml
@@ -138,6 +138,12 @@ jobs:
       - name: "📥 Checkout Repository"
         uses: actions/checkout@v6
 
+      - name: "🔧 Set up QEMU"
+        # Registers binfmt/QEMU so non-native arches (arm64, arm/v7) build under emulation.
+        # Only needed when this image targets a non-amd64 platform; skipped otherwise.
+        if: (matrix.image.platforms || inputs.platforms) != 'linux/amd64'
+        uses: docker/setup-qemu-action@v3
+
       - name: "🔧 Set up Docker Buildx"
         uses: docker/setup-buildx-action@v4
 
@@ -263,7 +269,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: ${{ inputs.cache && format('type=gha,scope={0}', matrix.image.name) || '' }}
+          # Read the scan build's amd64 layers (scope=<name>) AND a prior push run's
+          # arm64 layers (scope=<name>-push), and export everything to the distinct
+          # '-push' scope. Without cache-to, non-amd64 layers were rebuilt under QEMU on
+          # every run; a shared scope cannot be reused (GHA cache keys are immutable).
+          cache-from: |
+            ${{ inputs.cache && format('type=gha,scope={0}', matrix.image.name) || '' }}
+            ${{ inputs.cache && format('type=gha,scope={0}-push', matrix.image.name) || '' }}
+          cache-to: ${{ inputs.cache && format('type=gha,scope={0}-push,mode=max', matrix.image.name) || '' }}
           provenance: false
           sbom: false
 

--- a/docs/workflows/docker-build.md
+++ b/docs/workflows/docker-build.md
@@ -157,6 +157,8 @@ The Docker build action provides:
 | `build-args` | Build arguments as JSON object | `'{}'` |
 | `platforms` | Target platforms (comma-separated) | `'linux/amd64'` |
 | `multi-platform` | Enable multi-platform builds | `false` |
+| `checkout-fetch-depth` | Git history depth for the build checkout. `0` = full history (required for Dockerfile-version write-back and semver derivation); set `1` for a faster shallow checkout when neither is used | `0` |
+| `checkout-lfs` | Fetch Git LFS objects on the build checkout; set `false` to skip LFS blobs for a faster checkout | `true` |
 
 ### Push Configuration
 
@@ -176,6 +178,9 @@ The Docker build action provides:
 | `sign-image` | Sign image with Cosign | `false` |
 | `generate-sbom` | Generate Software Bill of Materials | `false` |
 | `sbom-format` | SBOM format: `'cyclonedx'`, `'spdx'` | `'cyclonedx'` |
+| `attest-sbom` | Create a GitHub (Sigstore) attestation for the SBOM. Requires `generate-sbom: true` | `false` |
+| `provenance` | SLSA build provenance for the pushed image: `'false'`, `'true'`, or `'mode=max'`. Enabling it attaches an attestation manifest | `'false'` |
+| `generate-vex` | Generate an OpenVEX document from the Trivy scan report (requires `security-scan: true` with the `trivy` scanner) | `false` |
 
 ### Docker Hub README Sync
 
@@ -332,6 +337,69 @@ sign-image: true
 generate-sbom: true
 sbom-format: 'cyclonedx'  # or 'spdx'
 ```
+
+### SBOM Attestation & Build Provenance (opt-in)
+
+Create a cryptographic, verifiable trail for the published image. Both default to
+today's behaviour (off) and require no changes for existing callers:
+
+```yaml
+generate-sbom: true
+attest-sbom: true      # Sigstore attestation for the SBOM (verifiable provenance)
+provenance: 'mode=max' # SLSA build provenance attached to the pushed image
+```
+
+The workflow already requests `attestations: write` and `id-token: write`; a caller
+using `secrets: inherit` and the default `GITHUB_TOKEN` needs no extra setup. Verify with:
+
+```bash
+gh attestation verify <sbom-file> --repo <owner>/<repo>
+```
+
+> **Note:** `provenance` attaches an attestation manifest, which changes the pushed
+> image from a single manifest to an image index. Leave it `'false'` (default) if you
+> depend on the exact single-manifest form.
+
+### OpenVEX Document (opt-in)
+
+Emit an [OpenVEX](https://github.com/openvex/spec) document from the Trivy scan report,
+marking every discovered CVE `under_investigation` and merging manual triage from
+`security/vex-overrides.json` when present:
+
+```yaml
+security-scan: true       # trivy scanner (default)
+generate-vex: true
+```
+
+The document is written into the security-reports artifact and exposed via the
+`vex-path` output.
+
+### Advanced Security Analysis
+
+When `security-scan: true` and the image is pushed, a separate advisory job runs the
+shared `modules-vulnerability-scan` workflow against the image, producing unified SARIF
+categories and a security score in the **Security** tab. It is advisory only
+(`fail-on-findings: false`) and never blocks the build or deploy.
+
+> **Note:** the container scan pulls the image without a registry login, so for **private
+> GHCR** images this advisory job may report a pull failure. The build, tags, digests,
+> outputs and deploy gate are unaffected.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `image-digest` | Built image digest |
+| `image-tags` | Generated image tags |
+| `image-url` | Full image URL with tag |
+| `image-size` / `image-size-display` | Image size (bytes / human-readable) |
+| `image-pushed` | Whether the image was pushed (`false` if the scan blocked it) |
+| `security-scan-passed` | Whether the in-build security scan passed |
+| `security-report` | Path to the security scan report |
+| `sbom-path` | Path to the generated SBOM (empty when `generate-sbom: false`) |
+| `sbom-attested` | Whether the SBOM was cryptographically attested |
+| `vex-path` | Path to the generated OpenVEX document (empty when `generate-vex: false`) |
+| `build-duration` | Build duration in seconds |
 
 ## Multi-Platform Builds
 


### PR DESCRIPTION
## Ziel

Performance- & Security-Optimierung des `docker-build`-Workflows (läuft in tausenden Repos via `@main`) — **strikt non-breaking**. Basierend auf einer Tiefenanalyse von `docker-build.yml` + `.github/actions/docker-build/action.yml` gegen den neuen `fork-docker-build.yml`.

**Leitplanke:** kein Input/Secret/Output umbenannt/entfernt, kein `true`-Default gekippt, keine Image-Tags/Digests/Manifest-Form beobachtbar geändert.

## Enthalten

### Phase 1 — risikofreie interne Fixes

**`.github/actions/docker-build/action.yml`**
- **arm64-Cache (größter Perf-Gewinn):** Push-Build exportiert in einen distinkten `-push`-Scope und liest beide Scopes → arm64 wird über Runs hinweg gecacht statt bei jedem Run unter QEMU neu gebaut.
- **QEMU-Setup** (`docker/setup-qemu-action`, gated auf `multi-platform`).
- **SARIF-Sichtbarkeit:** Upload `always()` + `continue-on-error` → Scan-Ergebnisse erreichen den Security-Tab auch wenn der Scan den Push blockt.

**`.github/workflows/docker-build.yml`**
- **`deploy`-Job** startet nur noch bei `deploy-enabled=true` (kein Leerlauf-Runner mehr).
- **`security-analysis`** auf `image-pushed` gegated + `continue-on-error`.
- **`dockerhub-readme`**-Checkout auf `fetch-depth: 1` + kein LFS.
- **`summary`**-Job mit Timeout + `contents: read`.

### Phase 2 — opt-in Supply-Chain-Features (alle Default = heutiges Verhalten)

- **`checkout-fetch-depth` / `checkout-lfs`** (Default `0` / `true`) — schnellerer Checkout auf Wunsch.
- **`provenance`** (Default `'false'`) — SLSA-Provenance, nur am Push-Build (Local-Scan-Build nutzt `load:true` und kann keine Attestation tragen).
- **`attest-sbom`** (Default `false`) — Sigstore-Attestation der SBOM via `sbom-attest`.
- **`generate-vex`** (Default `false`) — OpenVEX-Dokument aus dem Trivy-Report via `vex-generate`.
- **Neue Outputs:** `sbom-path`, `sbom-attested`, `vex-path`.
- Workflow erhält `attestations: write` + `id-token: write` (ohne Opt-in wirkungslos).

### Phase 3 — Integration & Konsistenz

- **`security-analysis`-Job** ruft jetzt `modules-vulnerability-scan.yml` (einheitliche SARIF-Kategorien/Scoring statt inline-Trivy); advisory-only (`fail-on-findings:false`), Deploy-Gate entkoppelt & auf `image-pushed` gegated (non-breaking). Caveat: der Container-Scan pullt ohne Registry-Login → bei **privaten GHCR**-Images kann der advisory-Job einen Pull-Fehler zeigen; Build/Tags/Digests/Outputs/Deploy-Gate bleiben unberührt.
- **`fork-docker-build.yml`**: gleiche Cache-/QEMU-Fixes wie in `docker-build` (arm64-Cache über `-push`-Scope, QEMU gated auf non-amd64).
- **Doku** (`docs/workflows/docker-build.md`): neue Inputs/Outputs + Advanced-Scan dokumentiert.

## Bewusst NICHT enthalten (BREAKING → eigener PR)
Doppel-Build/TOCTOU auflösen, `grype`/`snyk`/`LOW`-Gate scharf schalten, Attestation als Default, Manifest-Merge, Checkout-Default ändern.

## Canary (manuell durch Maintainer)
1. In einem Test-Repo (z.B. Outline) den Caller temporär auf `...docker-build.yml@feat/docker-build-optimize` pinnen.
2. Prüfen: amd64 **und** arm64 (zweiter Run → arm64 `CACHED`), Scan-Pass + Scan-Fail (SARIF im Security-Tab), alle Outputs unverändert, `deploy`-Gate intakt; opt-in `attest-sbom`/`provenance`/`generate-vex` einzeln.
3. Grün → merge; Caller zurück auf `@main`.
