### PR TITLE
feat!(ci): docker-build breaking security hardening

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -158,22 +158,22 @@ inputs:
     default: ''
   # SBOM Generation
   generate-sbom:
-    description: 'Generate Software Bill of Materials'
+    description: 'Generate Software Bill of Materials. BREAKING: default flipped to true (secure-by-default). Set false to skip SBOM generation.'
     required: false
-    default: 'false'
+    default: 'true'
   sbom-format:
     description: 'SBOM format (cyclonedx, spdx)'
     required: false
     default: 'cyclonedx'
   attest-sbom:
-    description: 'Create a GitHub (Sigstore) attestation for the generated SBOM. Requires generate-sbom=true and the caller job to grant attestations:write + id-token:write. Default false = no attestation (current behaviour).'
+    description: 'Create a GitHub (Sigstore) attestation for the generated SBOM. Requires generate-sbom=true and the caller job to grant attestations:write + id-token:write. BREAKING: default flipped to true (secure-by-default). A direct-action caller without those permissions must set attest-sbom=false.'
     required: false
-    default: 'false'
+    default: 'true'
   # Provenance
   provenance:
-    description: 'SLSA build provenance for the PUSHED image. Passed to docker/build-push-action (false, true, or mode=max). Default false preserves the current single-manifest form; enabling it attaches an attestation manifest (changes the observable manifest/index) - opt-in only.'
+    description: 'SLSA build provenance for the PUSHED image. Passed to docker/build-push-action (false, true, or mode=max). BREAKING: default flipped to mode=max, which attaches an attestation manifest and changes the pushed image to an index. Set false to keep the single-manifest form.'
     required: false
-    default: 'false'
+    default: 'mode=max'
   # VEX (Vulnerability Exploitability eXchange)
   generate-vex:
     description: 'Generate an OpenVEX document from the Trivy scan report (all CVEs under_investigation, merged with optional security/vex-overrides.json). Requires security-scan=true with the trivy scanner. Default false.'

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -611,7 +611,7 @@ runs:
             trivy image \
               --format json \
               --output "$REPORT_PATH" \
-              --severity ${{ inputs.security-fail-on }},HIGH,CRITICAL \
+              --severity CRITICAL,HIGH,MEDIUM,LOW \
               ${{ inputs.security-ignore-unfixed == 'true' && '--ignore-unfixed' || '' }} \
               "$PRIMARY_TAG" || echo "Trivy scan completed with issues"
 
@@ -619,7 +619,7 @@ runs:
             trivy image \
               --format sarif \
               --output "$SARIF_PATH" \
-              --severity ${{ inputs.security-fail-on }},HIGH,CRITICAL \
+              --severity CRITICAL,HIGH,MEDIUM,LOW \
               "$PRIMARY_TAG" || echo "SARIF generation completed"
             ;;
 
@@ -630,7 +630,8 @@ runs:
               curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
             fi
 
-            grype "$PRIMARY_TAG" -o json --file "$REPORT_PATH" || echo "Grype scan completed"
+            # Emit JSON (for gating) and SARIF (for the Security tab) in one scan.
+            grype "$PRIMARY_TAG" -o json="$REPORT_PATH" -o sarif="$SARIF_PATH" || echo "Grype scan completed"
             ;;
         esac
 
@@ -642,19 +643,33 @@ runs:
           CRITICAL_COUNT=0
           HIGH_COUNT=0
           MEDIUM_COUNT=0
+          LOW_COUNT=0
 
-          if [ "${{ inputs.security-scanner }}" = "trivy" ]; then
-            CRITICAL_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
-            HIGH_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
-            MEDIUM_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
-          fi
+          # Count per-scanner. grype JSON uses .matches[].vulnerability.severity with
+          # capitalised values (Critical/High/Medium/Low); trivy nests under .Results[].
+          case "${{ inputs.security-scanner }}" in
+            trivy)
+              CRITICAL_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              HIGH_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              MEDIUM_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              LOW_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "LOW")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              ;;
+            grype)
+              CRITICAL_COUNT=$(jq '[.matches[]?.vulnerability.severity | select(. == "Critical")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              HIGH_COUNT=$(jq '[.matches[]?.vulnerability.severity | select(. == "High")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              MEDIUM_COUNT=$(jq '[.matches[]?.vulnerability.severity | select(. == "Medium")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              LOW_COUNT=$(jq '[.matches[]?.vulnerability.severity | select(. == "Low")] | length' "$REPORT_PATH" 2>/dev/null || echo "0")
+              ;;
+          esac
 
           echo "🛡️ Security scan results:"
           echo "  • Critical: $CRITICAL_COUNT"
           echo "  • High: $HIGH_COUNT"
           echo "  • Medium: $MEDIUM_COUNT"
+          echo "  • Low: $LOW_COUNT"
 
-          # Determine if we should fail based on security-fail-on threshold
+          # Determine if we should fail based on security-fail-on threshold (fail when any
+          # vulnerability is AT OR ABOVE the configured severity).
           case "${{ inputs.security-fail-on }}" in
             CRITICAL)
               if [ "$CRITICAL_COUNT" -gt 0 ]; then
@@ -671,6 +686,12 @@ runs:
             MEDIUM)
               if [ "$CRITICAL_COUNT" -gt 0 ] || [ "$HIGH_COUNT" -gt 0 ] || [ "$MEDIUM_COUNT" -gt 0 ]; then
                 echo "❌ Found vulnerabilities at or above MEDIUM severity - blocking push"
+                SCAN_FAILED=true
+              fi
+              ;;
+            LOW)
+              if [ "$CRITICAL_COUNT" -gt 0 ] || [ "$HIGH_COUNT" -gt 0 ] || [ "$MEDIUM_COUNT" -gt 0 ] || [ "$LOW_COUNT" -gt 0 ]; then
+                echo "❌ Found vulnerabilities at or above LOW severity - blocking push"
                 SCAN_FAILED=true
               fi
               ;;

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -194,10 +194,10 @@ on:
         default: false
       
       generate-sbom:
-        description: 'Generate Software Bill of Materials'
+        description: 'Generate Software Bill of Materials. BREAKING: default flipped to true (secure-by-default). Set false to skip.'
         type: boolean
         required: false
-        default: false
+        default: true
 
       sbom-format:
         description: 'SBOM format (cyclonedx, spdx)'
@@ -206,16 +206,16 @@ on:
         default: 'cyclonedx'
 
       attest-sbom:
-        description: 'Create a GitHub (Sigstore) attestation for the generated SBOM. Requires generate-sbom=true. Default false.'
+        description: 'Create a GitHub (Sigstore) attestation for the generated SBOM. Requires generate-sbom=true. BREAKING: default flipped to true (secure-by-default).'
         type: boolean
         required: false
-        default: false
+        default: true
 
       provenance:
-        description: 'SLSA build provenance for the pushed image (false, true, or mode=max). Default false preserves the current single-manifest form; enabling it attaches an attestation manifest (opt-in).'
+        description: 'SLSA build provenance for the pushed image (false, true, or mode=max). BREAKING: default flipped to mode=max, which attaches an attestation manifest (image becomes an index). Set false to keep the single-manifest form.'
         type: string
         required: false
-        default: 'false'
+        default: 'mode=max'
 
       generate-vex:
         description: 'Generate an OpenVEX document from the Trivy scan report (requires security-scan=true with the trivy scanner). Default false.'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,10 +12,10 @@ on:
 
       # Checkout Configuration
       checkout-fetch-depth:
-        description: 'Git history depth for the build checkout. 0 (default) fetches full history — required for Dockerfile-version write-back and semver tag derivation. Set 1 for a faster shallow checkout when neither is used.'
+        description: 'Git history depth for the build checkout. BREAKING: default changed from 0 (full history) to 1 (shallow) for a faster checkout. Set 0 when a build step needs full history or tags (e.g. git-describe based versioning).'
         type: number
         required: false
-        default: 0
+        default: 1
 
       checkout-lfs:
         description: 'Fetch Git LFS objects on the build checkout. Default true preserves current behaviour (repos storing build assets in LFS). Set false to skip LFS blobs for a faster checkout.'


### PR DESCRIPTION
## Ziel

**Breaking** Follow-up zu #67. Verschärft die Sicherheits-Posture des `docker-build`-Workflows und ändert bewusst Defaults/Gates. Läuft in tausenden Repos via `@main` → **nur nach Canary mergen**.

> Stacked auf `feat/docker-build-optimize` (#67). Basis retargetet automatisch auf `main`, sobald #67 gemergt ist; danach zeigt der Diff nur noch die drei Breaking-Commits.

## Enthalten (review-verifizierbar, in dieser PR umgesetzt)

### 1. Attestation & SBOM als Default — `feat!(ci)` a99eeda
- `generate-sbom` `false → true`, `attest-sbom` `false → true`, `provenance` `'false' → 'mode=max'`.
- Jeder Build erzeugt+attestiert jetzt eine SBOM und hängt SLSA-Provenance an → **das gepushte Image wird zum OCI-Index** statt Single-Manifest.
- **Migration:** Single-Manifest-Form → `provenance: 'false'`. Direkte Action-Caller brauchen `attestations: write` + `id-token: write` (die `docker-build.yml` fordert sie bereits an) oder `attest-sbom: false`.

### 2. Checkout-Default auf Shallow — `perf!(ci)` e0d4fc3
- `checkout-fetch-depth` `0 → 1` (schnellerer Checkout).
- **Migration:** Build-Steps, die volle History/Tags brauchen → `checkout-fetch-depth: 0`. Tag/Semver-Tagging via metadata-action bleibt unberührt (leitet aus `github.ref` ab).

### 3. grype-Gate & LOW-Schwelle scharf — `fix!(ci)` ccc7207
- Bisher gated nur trivy; grype/snyk-Ergebnisse wurden nie gezählt (`scan-passed` immer true). LOW war nicht zählbar/durchsetzbar.
- Jetzt: grype-Findings werden gezählt und blocken wie trivy (+ grype-SARIF im Security-Tab); trivy scannt alle Severities; `security-fail-on: LOW` greift.
- **Migration:** Zuvor unter grype/LOW durchgelassene Images können jetzt blocken → höhere `security-fail-on` oder `security-scan: false`.

## NICHT enthalten — Design für Folge-Iteration (Publish-Path-Rewrite, Canary-pflichtig)

Doppel-Build/TOCTOU + Manifest-Merge sind **bewusst nicht** in dieser PR, weil sie den Image-Publish-Pfad umschreiben und nur mit echten Multi-Arch-Runs (amd64+arm64) verifizierbar sind — hier nicht ausführbar.

### Problem
Der aktuelle Ablauf baut **zweimal**: (1) `build-local` amd64 `load:true` → gescannt; (2) Push-Build (multi-arch) → baut aus Cache neu und pusht. Zwei Konsequenzen:
- **TOCTOU:** gescanntes und gepushtes Artefakt stammen aus getrennten Build-Invocations (theoretischer Drift).
- **arm64 ungescannt:** nicht-amd64-Arches werden **nur** im Push-Build gebaut und **nie** gescannt — ein verwundbares arm64-Image erreicht die Registry trotz aktivem Scan.

### Zieldesign (build once → scan exact → push by digest)
1. **Einmal bauen** — alle Zielplattformen in einem Build in ein OCI-Layout: `docker/build-push-action` mit `outputs: type=oci,dest=image.oci.tar` (statt zwei Builds).
2. **Jede Plattform scannen** — direkt aus dem OCI-Archiv: `trivy image --input image.oci.tar` bzw. `grype oci-archive:image.oci.tar`, über alle Plattformen iterieren; Gate auf der **Vereinigung** aller Findings.
3. **Exakt-gescanntes Artefakt by-digest publizieren** — kein Rebuild: `skopeo copy --all oci-archive:image.oci.tar docker://<reg>/<repo>:<tag>` (bzw. `buildx imagetools create`). Schließt das TOCTOU-Fenster und merged die Arch-Manifeste zu **einem Index** (Manifest-Merge).
4. Provenance/SBOM/Signing operieren auf dem publizierten Digest.

### Warum Canary-pflichtig
Schritte 1–3 schreiben den Publish-Pfad um; eine falsche `skopeo`/`imagetools`-Invocation publiziert kaputte/partielle Manifeste. Zu verifizieren im Canary: gescanntes Digest == gepushtes Digest, alle Plattformen im Index präsent, Tags auflösbar, alle Outputs unverändert, Scan-Fail blockt weiterhin.

### Migrations-Notizen (für die Folge-Iteration)
Build-Timing ändert sich (ein Build); `image-digest` wird das Index-Digest; Scan-Kosten skalieren mit Plattform-Anzahl.

## Canary vor Merge (manuell durch Maintainer)
1. Test-Repo-Caller temporär auf `...docker-build.yml@feat/docker-build-breaking` pinnen.
2. Prüfen: Default-Build erzeugt SBOM+Attestation+Provenance (Index-Manifest); `gh attestation verify`; grype-Scanner blockt bei Findings; `security-fail-on: LOW` blockt; Shallow-Checkout bricht keine Tag-Ableitung.
3. Grün → mergen; Caller zurück auf `@main`.
