### PR TITLE
fix(ci): stopped priority label from failing AI summary

### DIFF
--- a/.github/workflows/modules-ai-issue-summary.yml
+++ b/.github/workflows/modules-ai-issue-summary.yml
@@ -518,8 +518,14 @@ jobs:
           echo "🎯 Applying priority label..."
 
           if [ -n "$PRIORITY" ]; then
-            gh issue edit "$ISSUE_NUMBER" --add-label "priority-$PRIORITY"
-            echo "Added priority label: priority-$PRIORITY"
+            # Best-effort, matching the "Apply Suggested Labels" step: never fail the
+            # workflow when the priority-* label does not exist in the repo (these are
+            # opt-in per repo, unlike the default label set).
+            if gh issue edit "$ISSUE_NUMBER" --add-label "priority-$PRIORITY"; then
+              echo "Added priority label: priority-$PRIORITY"
+            else
+              echo "::notice::Skipped priority label 'priority-$PRIORITY' (create it in the repo to enable priority labelling)"
+            fi
           fi
 
       - name: 📊 Summary Report


### PR DESCRIPTION
## Problem

Der Job **🧠 Generate AI Summary** (`modules-ai-issue-summary.yml`, läuft via `@main` auf jeder PR/Issue) schlug rot fehl — konkret im Step **🎯 Apply Priority Label**.

Ursache: der Step rief `gh issue edit --add-label "priority-<level>"` **ohne Fehler-Guard**. Existiert das `priority-*`-Label im Repo nicht (sie sind opt-in und standardmäßig nicht vorhanden), gibt `gh` Exit 1 zurück → der ganze Summary-Job wird rot.

Beleg aus dem fehlgeschlagenen Run (PR #68):
```
failed to update .../pull/68: 'breaking-change' not found
failed to update .../pull/68: 'performance' not found
```
Der Schwester-Step **Apply Suggested Labels** fängt das bereits mit `|| echo "Failed to add label"` ab (daher nur soft-fail bei `breaking-change`/`performance`) — dem Priority-Step fehlte genau dieser Guard.

## Fix

Label-Zuweisung im Priority-Step **best-effort** gemacht, exakt nach dem Muster des Schwester-Steps: schlägt das Hinzufügen fehl, wird jetzt ein `::notice::` ausgegeben (Hinweis, das Label bei Bedarf anzulegen) statt den Job zu failen. Labelling bleibt advisory.

- Keine neuen Inputs/Permissions, keine Label-Erzeugung erzwungen (kein Seiteneffekt für die tausenden konsumierenden Repos).
- Validiert mit actionlint 1.7.7 (nur die vorbestehende `models: read`-Scope-Warnung, unabhängig von diesem Change) + `bash -n`.

## Test
Nach Merge auf `main` läuft der Summary-Job auf der nächsten PR grün; fehlende `priority-*`-Labels erzeugen nur noch eine Notice statt eines roten Checks.
