### PR TITLE
feat(ci): single-build-scan — close scan→push TOCTOU (opt-in)

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -109,6 +109,17 @@ inputs:
     description: 'Push images on pull requests'
     required: false
     default: 'false'
+  single-build-scan:
+    description: >-
+      Close the scan->push TOCTOU window: build the image ONCE, scan it, then push the
+      EXACT scanned artifact (docker push, no rebuild) instead of building a second time.
+      Currently applies to single-platform builds only; multi-platform (multi-platform=true)
+      falls back to the standard two-build flow. Default false preserves current behaviour.
+      NOTE: the fast path uses `docker push`, which does NOT attach SLSA build provenance to
+      the manifest (unlike the buildx push). SBOM file attestation (attest-sbom) still works;
+      set provenance:'false' if you enable this to avoid expecting provenance that isn't there.
+    required: false
+    default: 'false'
   # Caching
   cache-enabled:
     description: 'Enable build caching'
@@ -206,8 +217,9 @@ inputs:
 outputs:
   image-digest:
     description: 'Image digest'
-    # Use push digest if available, otherwise local build digest
-    value: ${{ steps.build.outputs.digest || steps.build-local.outputs.digest }}
+    # Prefer the standard push digest, then the single-build fast-path push digest,
+    # otherwise the local build digest.
+    value: ${{ steps.build.outputs.digest || steps.push-scanned.outputs.digest || steps.build-local.outputs.digest }}
   image-tags:
     description: 'Generated image tags'
     value: ${{ steps.meta.outputs.tags }}
@@ -715,7 +727,10 @@ runs:
 
     - name: 🚀 Push Docker Image
       id: build
-      if: inputs.push == 'true' && (github.event_name != 'pull_request' || inputs.push-on-pr == 'true') && (inputs.security-scan != 'true' || steps.security.outputs.scan-passed == 'true')
+      # Standard two-build push. Skipped when the single-build fast path is active
+      # (single-build-scan=true AND single-platform) - the Push Scanned Image step below
+      # pushes the already-scanned image instead, closing the scan->push TOCTOU window.
+      if: inputs.push == 'true' && (github.event_name != 'pull_request' || inputs.push-on-pr == 'true') && (inputs.security-scan != 'true' || steps.security.outputs.scan-passed == 'true') && (inputs.single-build-scan != 'true' || inputs.multi-platform == 'true')
       uses: docker/build-push-action@v7
       env:
         # See build-local step above for rationale - opt-in via verbose-build-summary input.
@@ -741,6 +756,37 @@ runs:
         # scan build uses load:true (docker exporter), which cannot hold attestations.
         provenance: ${{ inputs.provenance }}
         sbom: false
+
+    - name: 🚀 Push Scanned Image (single-build, no rebuild)
+      id: push-scanned
+      # Fast path: push the EXACT image that build-local built and the scan verified, with
+      # no second build - closing the scan->push TOCTOU window. Only for single-platform
+      # builds (docker load/push handle one arch); the standard push step covers the rest.
+      # Same push gate as the standard step (respects push / push-on-pr / scan-passed).
+      if: inputs.push == 'true' && (github.event_name != 'pull_request' || inputs.push-on-pr == 'true') && (inputs.security-scan != 'true' || steps.security.outputs.scan-passed == 'true') && inputs.single-build-scan == 'true' && inputs.multi-platform != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "🚀 Pushing the exact scanned image (no rebuild)..."
+
+        # Push every tag build-local loaded (primary + any secondary-registry tags). All
+        # tags reference the same local image, so this uploads the scanned bytes verbatim.
+        pushed_any=false
+        while IFS= read -r TAG; do
+          [ -z "$TAG" ] && continue
+          echo "  → $TAG"
+          docker push "$TAG"
+          pushed_any=true
+        done <<< "${{ steps.meta.outputs.tags }}"
+
+        # Resolve the registry manifest digest from the first tag's RepoDigests.
+        DIGEST=""
+        if [ "$pushed_any" = "true" ]; then
+          FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)
+          DIGEST=$(docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' "$FIRST_TAG" 2>/dev/null | head -n1 | sed 's/.*@//' || true)
+        fi
+        echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+        echo "✅ Pushed scanned image (digest: ${DIGEST:-unknown})"
 
     - name: 📊 Collect Build Information
       id: build-info
@@ -796,14 +842,15 @@ runs:
           go install github.com/sigstore/cosign/v2/cmd/cosign@latest
         fi
 
-        # Sign all tags using the push digest
+        # Sign all tags using the push digest (standard push, or the single-build fast-path push).
+        PUSH_DIGEST="${{ steps.build.outputs.digest || steps.push-scanned.outputs.digest }}"
         echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
           if [ -n "$tag" ]; then
-            echo "Signing: $tag@${{ steps.build.outputs.digest }}"
+            echo "Signing: $tag@${PUSH_DIGEST}"
             if [ -n "$COSIGN_PRIVATE_KEY" ]; then
-              echo "$COSIGN_PRIVATE_KEY" | cosign sign --key env://COSIGN_PRIVATE_KEY --yes "$tag@${{ steps.build.outputs.digest }}"
+              echo "$COSIGN_PRIVATE_KEY" | cosign sign --key env://COSIGN_PRIVATE_KEY --yes "$tag@${PUSH_DIGEST}"
             else
-              cosign sign --yes "$tag@${{ steps.build.outputs.digest }}"
+              cosign sign --yes "$tag@${PUSH_DIGEST}"
             fi
           fi
         done

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -147,7 +147,13 @@ on:
         type: boolean
         required: false
         default: false
-      
+
+      single-build-scan:
+        description: 'Close the scan->push TOCTOU window: build once, scan, then push the exact scanned image (no rebuild). Single-platform only; multi-platform falls back to the standard flow. Note: the fast path uses docker push and does not attach SLSA provenance. Default false.'
+        type: boolean
+        required: false
+        default: false
+
       # Testing Configuration
       run-tests:
         description: 'Run tests before building'
@@ -489,6 +495,7 @@ jobs:
           release-version: ${{ inputs.release-version }}
           push: ${{ inputs.push }}
           push-on-pr: ${{ inputs.push-on-pr }}
+          single-build-scan: ${{ inputs.single-build-scan }}
           cache-enabled: ${{ inputs.cache-enabled }}
           cache-mode: ${{ inputs.cache-mode }}
           cache-scope: ${{ inputs.cache-scope }}

--- a/docs/workflows/docker-build.md
+++ b/docs/workflows/docker-build.md
@@ -385,6 +385,25 @@ categories and a security score in the **Security** tab. It is advisory only
 > GHCR** images this advisory job may report a pull failure. The build, tags, digests,
 > outputs and deploy gate are unaffected.
 
+### Single-Build Scan — close the scan→push TOCTOU (opt-in)
+
+By default the action builds twice: once locally (`load`ed and scanned) and once more to
+push. That leaves a time-of-check-to-time-of-use gap between the *scanned* artifact and the
+*pushed* one. Enable `single-build-scan` to build **once**, scan it, then `docker push` the
+**exact** scanned image — no rebuild:
+
+```yaml
+single-build-scan: true
+multi-platform: false      # single-platform only (see below)
+```
+
+- **Scope:** applies to **single-platform** builds. With `multi-platform: true` it falls
+  back to the standard two-build flow (scanning every architecture of a pushed multi-arch
+  index still needs the design tracked in the breaking PR).
+- **Provenance caveat:** the fast path uses `docker push`, which does **not** attach SLSA
+  build provenance. SBOM file attestation (`attest-sbom`) still works. Set
+  `provenance: 'false'` when enabling this if you would otherwise expect provenance.
+
 ## Outputs
 
 | Output | Description |


### PR DESCRIPTION
## Ziel

Erste, **verifizierbar sichere** Umsetzung des in #68 designten TOCTOU-Rewrites — als **opt-in** (`single-build-scan`, Default `false`), stacked auf `feat/docker-build-breaking` (#68).

> ⚠️ **Registry-/Runner-Verhalten ist hier nicht lokal ausführbar.** Statisch validiert (actionlint 1.7.7 + `bash -n`). **Vor jedem Default-Flip zwingend Canary-getestet.**

## Problem (Wiederholung aus #68)

Der Default-Flow baut **zweimal**: `build-local` (amd64, `load`, gescannt) und danach der Push-Build (Rebuild aus Cache → Push). Dazwischen liegt ein **Time-of-Check-to-Time-of-Use-Fenster**: gescanntes und gepushtes Artefakt stammen aus getrennten Build-Invocations.

## Umsetzung in dieser PR (bewusst eng gefasst, geringes Risiko)

Neuer opt-in Input **`single-build-scan`** (Default `false`):
- Bei **single-platform** + `single-build-scan: true`: nach bestandenem Scan wird das **exakt gescannte** Image via `docker push` hochgeladen — **kein zweiter Build**. Schließt das TOCTOU-Fenster und spart einen kompletten Build.
- Der Standard-Push-Step wird in diesem Fall übersprungen; beide Push-Wege teilen dasselbe Gate (`push`/`push-on-pr`/`scan-passed`) und sind gegenseitig exklusiv.
- `image-digest`-Output und Cosign-Signing fallen auf das Fast-Path-Push-Digest zurück.

**Bewusst nur `docker push` / einfache Werkzeuge** — kein `skopeo`/OCI-Archiv/Multi-Arch-Trivy, deren Verhalten ich ohne Live-Run nicht verifizieren kann. Das hält die untestbare Fläche minimal.

## Grenzen (ehrlich)

- **Nur single-platform.** `multi-platform: true` fällt auf den Standard-Flow zurück. Das **arm64-ungescannt**-Problem bei Multi-Arch bleibt offen — es braucht den build-once→OCI→scan-all→push-by-digest-Weg (skopeo/imagetools), der nur mit echten Multi-Arch-Canary-Runs verifizierbar ist. Weiterhin als Design in #68 dokumentiert.
- **Keine SLSA-Provenance im Fast-Path.** `docker push` hängt keine Provenance-Attestation an (anders als der buildx-Push). SBOM-**File**-Attestation (`attest-sbom`) funktioniert weiter. Bei `single-build-scan: true` daher `provenance: 'false'` setzen. Auf dem Input und in den Docs dokumentiert.

## Canary vor Merge (manuell)

1. Test-Repo-Caller auf `...docker-build.yml@feat/docker-build-toctou` pinnen, `single-build-scan: true`, single-arch.
2. Prüfen: nur **ein** Build im Log; gepushtes Digest == gescanntes Image; Tags auflösbar; `image-digest`-Output gesetzt; Scan-Fail blockt weiterhin den Push; Cosign (falls aktiv) signiert korrektes Digest.
3. Grün → mergen. Default-Flip (`single-build-scan` → true) erst nach breiterem Canary erwägen.

## Validierung
- actionlint 1.7.7: pass (nur die vorbestehende, unabhängige `@main`-Input-Auflösungs-Warnung der IDE).
- `bash -n` auf dem neuen Push-Step: pass.
- YAML-Parse: pass.
