### PR TITLE
feat(validate-compose): added compose-profiles input for profiled services

### DIFF
--- a/.github/workflows/modules-validate-compose.yml
+++ b/.github/workflows/modules-validate-compose.yml
@@ -15,6 +15,12 @@ on:
         type: string
         default: ''
 
+      compose-profiles:
+        description: 'Compose profiles to activate during validation so profile-gated services are rendered. Use "*" (or "all") to auto-detect and enable every declared profile, or a comma-separated list (e.g. "backup,debug"). Empty = no profiles (default, backward compatible).'
+        required: false
+        type: string
+        default: ''
+
       working-directory:
         description: 'Working directory for validation'
         required: false
@@ -237,6 +243,27 @@ jobs:
 
           echo "📋 Compose files: $COMPOSE_FILES"
 
+          # Activate Compose profiles so profile-gated services are rendered.
+          # `docker compose config` omits profiled services unless their profile
+          # is active; without this, validate-services can never see them.
+          PROFILES_INPUT='${{ inputs.compose-profiles }}'
+          if [ -n "$PROFILES_INPUT" ]; then
+            case "$PROFILES_INPUT" in
+              '*'|all|ALL)
+                # Auto-detect every profile declared across the compose file(s)
+                COMPOSE_PROFILES=$(docker compose $COMPOSE_FILES $ENV_OPT config --profiles 2>/dev/null | sort -u | tr '\n' ',' | sed 's/,$//')
+                ;;
+              *)
+                # Literal comma-separated profile list
+                COMPOSE_PROFILES="$PROFILES_INPUT"
+                ;;
+            esac
+            export COMPOSE_PROFILES
+            # Propagate to later steps (e.g. image-reference check)
+            echo "COMPOSE_PROFILES=$COMPOSE_PROFILES" >> "$GITHUB_ENV"
+            echo "🎚️ Activated Compose profiles: ${COMPOSE_PROFILES:-<none declared>}"
+          fi
+
           # Run validation
           echo "::group::Docker Compose Config Output"
           if docker compose $COMPOSE_FILES $ENV_OPT config 2>&1 | tee /tmp/compose-output.txt; then
@@ -398,6 +425,11 @@ jobs:
           echo "| **Services Found** | ${{ steps.validate.outputs.service-count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| **Service Names** | ${{ steps.validate.outputs.services }} |" >> $GITHUB_STEP_SUMMARY
           echo "| **Working Directory** | \`${{ inputs.working-directory }}\` |" >> $GITHUB_STEP_SUMMARY
+
+          # COMPOSE_PROFILES is propagated via $GITHUB_ENV from the validate step
+          if [ -n "$COMPOSE_PROFILES" ]; then
+            echo "| **Profiles Activated** | \`$COMPOSE_PROFILES\` |" >> $GITHUB_STEP_SUMMARY
+          fi
 
           WARNINGS_OUTPUT="${{ steps.validate.outputs.warnings }}"
           if [ -n "$WARNINGS_OUTPUT" ] && [ "$WARNINGS_OUTPUT" != "" ]; then

--- a/docs/workflows/modules-validate-compose.md
+++ b/docs/workflows/modules-validate-compose.md
@@ -10,6 +10,7 @@ This reusable workflow module provides:
 - **Service Discovery**: Extracts and reports all defined services
 - **Environment Handling**: Auto-generates dummy `.env` files for validation when originals contain secrets
 - **Multiple File Support**: Validates single or multiple compose files
+- **Profile Support**: Optionally activates Compose profiles so profile-gated services are validated
 - **Image Reference Checking**: Optional verification that referenced images exist
 
 ## Quick Start
@@ -65,6 +66,7 @@ jobs:
 |-----------|-------------|---------|
 | `compose-file` | Path to Docker Compose file | `'docker-compose.yml'` |
 | `compose-files` | Multiple compose files as JSON array | `''` |
+| `compose-profiles` | Compose profiles to activate so profile-gated services are rendered. `'*'`/`'all'` auto-detects and enables every declared profile; or a comma-separated list (e.g. `'backup,debug'`). Empty = no profiles | `''` |
 | `working-directory` | Working directory for validation | `'.'` |
 
 ### Environment Configuration
@@ -217,6 +219,25 @@ jobs:
         run: echo "Database service is configured"
 ```
 
+### Example 7: Validating Profile-Gated Services
+
+By default `docker compose config` hides services behind a Compose
+[profile](https://docs.docker.com/compose/how-tos/profiles/), so
+`validate-services` cannot see them. Activate the profile(s) to include
+those services in validation:
+
+```yaml
+jobs:
+  validate:
+    uses: bauer-group/automation-templates/.github/workflows/modules-validate-compose.yml@main
+    with:
+      compose-file: 'docker-compose.yml'
+      # Enable every declared profile (or list them: 'backup,debug')
+      compose-profiles: '*'
+      # Now a profiles:[backup] service can be required
+      validate-services: '["database", "backup"]'
+```
+
 ## Environment Variable Handling
 
 The module intelligently handles environment variables required by your compose files:
@@ -304,6 +325,17 @@ Ensure files are specified in the correct order (base first):
 
 ```yaml
 compose-files: '["docker-compose.yml", "docker-compose.prod.yml"]'
+```
+
+### Required Service "not found" for a Profiled Service
+
+If `validate-services` reports a service as not found even though it is
+defined, the service is likely gated behind a Compose `profiles:` key.
+`docker compose config` omits profiled services unless the profile is
+active. Activate it during validation:
+
+```yaml
+compose-profiles: '*'   # or a comma-separated list, e.g. 'backup'
 ```
 
 ### Image Reference Check Failures


### PR DESCRIPTION
## Problem

`docker compose config` (and `config --services`) **omits any service gated behind a Compose `profiles:` key** unless that profile is active. The `modules-validate-compose` workflow never activates profiles, so `validate-services` can never assert a profile-gated service.

Real failure that motivated this — `CS-BackupHelper`, whose backup sidecar is intentionally `profiles: ["backup"]` (on-demand):

```
📦 Found 1 service(s): database
  ✅ Service 'database' found
  ❌ Required service 'backup' not found
##[error]Process completed with exit code 1.
```

## Change

New optional input **`compose-profiles`** (default `''` → unchanged behavior, fully backward compatible for all existing callers):

- `'*'` / `'all'` → auto-detect and enable **every** declared profile via `docker compose config --profiles`
- comma-separated list (e.g. `'backup,debug'`) → activate those profiles literally
- empty → no profiles (previous behavior)

Implementation details:

- `COMPOSE_PROFILES` is `export`ed in the validate step and propagated via `$GITHUB_ENV`, so the **image-reference check** renders the same set of services.
- The job summary lists the activated profiles when set.
- Docs (`docs/workflows/modules-validate-compose.md`) updated: input table, Example 7, troubleshooting entry, overview bullet.

## Verification

End-to-end against a sidecar compose whose only service is `profiles: ["backup"]`:

| Step | Result |
|------|--------|
| `config --profiles` | auto-detects `backup` |
| `config --services` (no activation) | *empty* (the bug) |
| `config --services` with `COMPOSE_PROFILES=backup` | `backup` ✅ |

YAML validated with `yq`; embedded bash `case` block checked with `bash -n`.

## Backward compatibility

No behavior change for existing callers — the new input defaults to empty and the profile block is skipped entirely when unset.
