### PR TITLE
fix(sync-upstream): surfaced swallowed API errors

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -227,22 +227,38 @@ jobs:
           EOF
           )
 
+          # Issues can be disabled outright - the GitHub default for forks, which
+          # is exactly where this workflow runs. Degrade to a log report instead
+          # of failing: the conflict is already surfaced as a warning above, and
+          # an unfileable issue must not turn a reported conflict into a red job.
+          if [ "$(gh api "/repos/${{ github.repository }}" --jq '.has_issues' 2>/dev/null || echo false)" != "true" ]; then
+            echo "::warning::Issues are disabled on ${{ github.repository }} - reporting the conflict in the log instead."
+            printf '%s\n' "$BODY"
+            exit 0
+          fi
+
           # Ensure labels exist (best-effort), then upsert the issue.
           gh label create sync      --color "1D76DB" --description "Upstream sync automation"      >/dev/null 2>&1 || true
           gh label create conflict  --color "B60205" --description "Requires manual resolution"    >/dev/null 2>&1 || true
           gh label create automated --color "0E8A16" --description "Created by automation"          >/dev/null 2>&1 || true
 
+          # `|| true` guards the assignment: `pipefail` propagates a failing
+          # `gh issue list` to the pipeline, which under `bash -e` would abort
+          # the step before the issue is ever attempted.
           EXISTING=$(gh issue list --state open --label sync --label conflict --json number,title \
-            --jq '.[] | [.number, .title] | @tsv' 2>/dev/null | awk -F'\t' -v t="$TITLE" '$2==t {print $1; exit}')
+            --jq '.[] | [.number, .title] | @tsv' 2>/dev/null | awk -F'\t' -v t="$TITLE" '$2==t {print $1; exit}' || true)
 
           if [ -n "${EXISTING:-}" ]; then
-            gh issue comment "$EXISTING" --body "Konflikt erneut aufgetreten - Run: ${RUN_URL}"
+            gh issue comment "$EXISTING" --body "Konflikt erneut aufgetreten - Run: ${RUN_URL}" \
+              || echo "::warning::Could not comment on issue #${EXISTING}."
             echo "🔁 Bestehendes Issue #${EXISTING} aktualisiert."
-          else
-            gh issue create --title "$TITLE" --body "$BODY" \
-              --label sync --label conflict --label automated \
-              || gh issue create --title "$TITLE" --body "$BODY"
+          elif gh issue create --title "$TITLE" --body "$BODY" \
+                 --label sync --label conflict --label automated \
+               || gh issue create --title "$TITLE" --body "$BODY"; then
             echo "🆕 Konflikt-Issue erstellt."
+          else
+            echo "::warning::Could not create the conflict issue - reporting it in the log instead."
+            printf '%s\n' "$BODY"
           fi
 
   # ---------------------------------------------------------------------------
@@ -334,21 +350,32 @@ jobs:
           EOF
           )
 
+          # Same degradation as Stage A: a fork with Issues disabled must still
+          # get the conflict reported, just in the log rather than as an issue.
+          if [ "$(gh api "/repos/${{ github.repository }}" --jq '.has_issues' 2>/dev/null || echo false)" != "true" ]; then
+            echo "::warning::Issues are disabled on ${{ github.repository }} - reporting the conflict in the log instead."
+            printf '%s\n' "$BODY"
+            exit 0
+          fi
+
           gh label create sync      --color "1D76DB" --description "Upstream sync automation"   >/dev/null 2>&1 || true
           gh label create conflict  --color "B60205" --description "Requires manual resolution" >/dev/null 2>&1 || true
           gh label create automated --color "0E8A16" --description "Created by automation"       >/dev/null 2>&1 || true
 
           EXISTING=$(gh issue list --state open --label sync --label conflict --json number,title \
-            --jq '.[] | [.number, .title] | @tsv' 2>/dev/null | awk -F'\t' -v t="$TITLE" '$2==t {print $1; exit}')
+            --jq '.[] | [.number, .title] | @tsv' 2>/dev/null | awk -F'\t' -v t="$TITLE" '$2==t {print $1; exit}' || true)
 
           if [ -n "${EXISTING:-}" ]; then
-            gh issue comment "$EXISTING" --body "Konflikt erneut aufgetreten - Run: ${RUN_URL}"
+            gh issue comment "$EXISTING" --body "Konflikt erneut aufgetreten - Run: ${RUN_URL}" \
+              || echo "::warning::Could not comment on issue #${EXISTING}."
             echo "🔁 Bestehendes Issue #${EXISTING} aktualisiert."
-          else
-            gh issue create --title "$TITLE" --body "$BODY" \
-              --label sync --label conflict --label automated \
-              || gh issue create --title "$TITLE" --body "$BODY"
+          elif gh issue create --title "$TITLE" --body "$BODY" \
+                 --label sync --label conflict --label automated \
+               || gh issue create --title "$TITLE" --body "$BODY"; then
             echo "🆕 Konflikt-Issue erstellt."
+          else
+            echo "::warning::Could not create the conflict issue - reporting it in the log instead."
+            printf '%s\n' "$BODY"
           fi
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -125,7 +125,20 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Verify this is a GitHub-native fork (merge-upstream requires a parent).
-          PARENT=$(gh api "/repos/${REPO}" --jq '.parent.full_name // ""' 2>/dev/null || echo "")
+          # Keep an API failure distinguishable from "repo has no parent": masking
+          # it with `2>/dev/null || echo ""` reports an invalid token as "not a
+          # fork", which sends whoever reads the log down the wrong path.
+          REPO_RC=0
+          REPO_JSON=$(gh api "/repos/${REPO}" 2>&1) || REPO_RC=$?
+          if [ $REPO_RC -ne 0 ]; then
+            printf '%s\n' "$REPO_JSON"
+            echo "status=error" >> "$GITHUB_OUTPUT"
+            echo "merge-type=none" >> "$GITHUB_OUTPUT"
+            echo "::error::Cannot read '${REPO}' via the API (see response above). Check that the token is valid and can access the repository."
+            exit 1
+          fi
+
+          PARENT=$(printf '%s' "$REPO_JSON" | jq -r '.parent.full_name // ""')
           if [ -z "$PARENT" ]; then
             echo "::error::'${REPO}' is not a GitHub-native fork (no parent repository). The merge-upstream API requires a fork. Use a manual upstream-remote sync instead."
             echo "status=not-a-fork" >> "$GITHUB_OUTPUT"
@@ -143,11 +156,16 @@ jobs:
           fi
 
           # Call the "Sync fork" API. Capture body + any error text, plus exit code.
+          # `|| RC=$?` is load-bearing: Actions runs `run:` blocks under `bash -e`
+          # (the `set -uo pipefail` above does not clear it), so a bare
+          # `RESPONSE=$(gh api ...)` aborts the step on any non-2xx response --
+          # before the printf below. That left the whole ladder unreachable and
+          # the job failing with no diagnosis at all.
+          RC=0
           RESPONSE=$(gh api --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${REPO}/merge-upstream" \
-            -f branch="${MIRROR_BRANCH}" 2>&1)
-          RC=$?
+            -f branch="${MIRROR_BRANCH}" 2>&1) || RC=$?
           printf '%s\n' "$RESPONSE"
 
           if [ $RC -eq 0 ]; then
@@ -160,6 +178,11 @@ jobs:
               echo "status=synced" >> "$GITHUB_OUTPUT"
               echo "✅ Synced '${MIRROR_BRANCH}' from upstream (merge_type=${MERGE_TYPE})."
             fi
+          elif printf '%s' "$RESPONSE" | grep -qiE 'HTTP 40[13]|Bad credentials|Resource not accessible|SAML enforcement'; then
+            echo "status=auth-error" >> "$GITHUB_OUTPUT"
+            echo "merge-type=none" >> "$GITHUB_OUTPUT"
+            echo "::error::Upstream sync for '${MIRROR_BRANCH}' was rejected with 401/403. The token (PAT_READWRITE_ORGANISATION, else GITHUB_TOKEN) needs write access to repository contents on '${REPO}' - fine-grained: 'Contents: Read and write', classic: 'repo'; SAML orgs additionally require the PAT to be SSO-authorised. NB: on a public repo the fork check above still passes with a read-only token, so this is the first call that actually exercises write access."
+            exit 1
           elif printf '%s' "$RESPONSE" | grep -qiE 'HTTP 409|merge conflict'; then
             echo "status=conflict" >> "$GITHUB_OUTPUT"
             echo "merge-type=none" >> "$GITHUB_OUTPUT"
@@ -355,6 +378,7 @@ jobs:
               dry-run)    echo "🔍 Dry run" ;;
               conflict)   echo "⚠️ Conflict" ;;
               not-a-fork) echo "❌ Not a fork" ;;
+              auth-error) echo "🔐 Token rejected (401/403)" ;;
               *)          echo "❌ Error" ;;
             esac
           }


### PR DESCRIPTION
Two commits, one defect class: **API errors swallowed by `bash -e`**, which
turned every failure mode of this workflow into a bare
`Process completed with exit code 1` with no output to act on.

GitHub Actions starts `run:` blocks with `bash --noprofile --norc -e -o pipefail`.
The scripts' own `set -uo pipefail` does **not** clear that `-e`. The exit status
of a plain assignment is the status of its command substitution, so
`X=$(gh ... )` aborts the step on any non-2xx — before the error handling below
it ever runs.

Verified locally:

```console
$ bash -e -o pipefail -c 'set -uo pipefail; R=$(false 2>&1); RC=$?; echo "REACHED: RC=$RC"'
$ echo $?
1                       # nothing printed — exactly the CI symptom

$ bash -e -o pipefail -c 'set -uo pipefail; RC=0; R=$(false 2>&1) || RC=$?; echo "REACHED: RC=$RC"'
REACHED: RC=1
$ echo $?
0
```

## 1. `fix(sync-upstream): surfaced swallowed API errors`

- `|| RC=$?` on the `merge-upstream` call, so the step survives a non-2xx and
  actually prints the API response.
- New `auth-error` status for 401/403 naming the concrete requirement
  (`Contents: Read and write` fine-grained, `repo` classic, plus SSO
  authorisation in SAML orgs). A rejected token needs secret rotation, not repo
  work — worth telling apart from a conflict.
- The fork-parent probe no longer masks API failures with
  `2>/dev/null || echo ""`, which reported an invalid token as *"not a
  GitHub-native fork"* — a misleading diagnosis.
- `auth-error` rendered in the job summary.

On a **public** fork the parent probe succeeds even with a read-only token, so
`merge-upstream` is the first call that exercises write access at all. That
asymmetry is why the original failure looked like a sync problem rather than a
token problem.

## 2. `fix(sync-upstream): kept conflict reports non-fatal`

Both conflict reporters carried the same defect: with `pipefail`, a failing
`gh issue list` propagates through the pipeline and aborts the assignment.

Not hypothetical — **forks have Issues disabled by default**, so
`create-issue-on-conflict: true` turned every reported conflict into a red job
on exactly the repositories this workflow targets.

- `has_issues` is checked up front; if Issues are off, the report goes to the
  log and the step exits 0.
- `|| true` on the `EXISTING=` assignment.
- Issue creation/commenting degrades to a `::warning::` instead of failing.

A conflict remains a warning either way — surfaced, not swallowed.

## Evidence

Reproduced end-to-end on `mirrored-projects/MS365-SMTPGateway`:

| Run | Stage A | Stage B | Log |
|---|---|---|---|
| [30716810130](https://github.com/mirrored-projects/MS365-SMTPGateway/actions/runs/30716810130) (before) | ❌ exit 1 | — | no output at all |
| [30717586872](https://github.com/mirrored-projects/MS365-SMTPGateway/actions/runs/30717586872) (token fixed) | ✅ synced | ❌ died in reporter | conflict correctly warned, then silence |

Stage B's merge step needs no change — its `git merge` sits in an `if`
condition, which `-e` exempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)