### PR TITLE
fix(ci): removed the PSR GitPython compat shim

### DIFF
--- a/.github/workflows/python-semantic-release.yml
+++ b/.github/workflows/python-semantic-release.yml
@@ -323,48 +323,8 @@ jobs:
       - name: 📦 Install python-semantic-release and build tools
         run: |
           python -m pip install --upgrade pip
-          pip install python-semantic-release build
+          pip install "python-semantic-release>10.6.1" build
 
-          # Compatibility shim: python-semantic-release 10.6.1 + GitPython >= 3.1.60
-          #
-          # GitPython 3.1.60 removed Actor.name_email_regex while fixing GHSA-g5vv-9gxw-82hx
-          # (ReDoS in commit author/committer parsing). PSR 10.6.1 still reads that attribute
-          # on every config load, so `semantic-release version` aborts before inspecting a
-          # single commit with: type object 'Actor' has no attribute 'name_email_regex'
-          #
-          # We deliberately keep GitPython current rather than pinning back to 3.1.59:
-          # Actor._from_string no longer uses the regex, so untrusted commit data stays on the
-          # hardened code path. PSR applies it only to the configured (trusted) author string
-          # from pyproject.toml or the environment.
-          #
-          # The shim is loaded via PYTHONPATH scoped to the semantic-release call only, so it
-          # does not leak into the package build or any other Python process in this job.
-          #
-          # Upstream fix: python-semantic-release#1477 (open, unreleased as of 2026-08-26).
-          # TODO: remove this shim once a PSR release containing #1477 is available.
-          mkdir -p "$RUNNER_TEMP/psr-compat"
-          cat > "$RUNNER_TEMP/psr-compat/sitecustomize.py" <<'PSR_COMPAT'
-          import re
-
-          # NOTE: import via `from git.util import ...` -- the attribute `git.util` resolves to
-          # git.index.util, so `import git.util` would silently patch the wrong module.
-          try:
-              from git.util import Actor
-          except ImportError:
-              pass
-          else:
-              if not hasattr(Actor, "name_email_regex"):
-                  Actor.name_email_regex = re.compile(r"(.*) <(.*?)>")
-          PSR_COMPAT
-
-          # Fail loudly here rather than silently shipping an ineffective shim into the
-          # release step (e.g. if a future GitPython moves Actor again).
-          PYTHONPATH="$RUNNER_TEMP/psr-compat" python -c "
-          from git import Actor
-          assert Actor.name_email_regex.match('github-actions[bot] <bot@users.noreply.github.com>')
-          print('OK: Actor.name_email_regex available for python-semantic-release')
-          "
-          
           # Install tomli for Python <3.11 compatibility (needed for pyproject.toml parsing)
           python -c "import sys; sys.exit(0 if sys.version_info >= (3,11) else 1)" || pip install tomli
           
@@ -405,7 +365,7 @@ jobs:
           fi
 
           # Run semantic release (creates version, commit, tag, release, and builds packages)
-          PYTHONPATH="$RUNNER_TEMP/psr-compat" semantic-release --verbose version
+          semantic-release --verbose version
           
           # Check if release was created and extract build information
           if git describe --exact-match --tags HEAD 2>/dev/null; then


### PR DESCRIPTION
> ⛔ **Do not merge yet.** Blocked on an upstream release — see *Merge precondition*.

Prepared in advance so the cleanup is a review-and-merge, not a re-investigation.

## Background

GitPython **3.1.60** removed `Actor.name_email_regex` while fixing [GHSA-g5vv-9gxw-82hx](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-g5vv-9gxw-82hx) (ReDoS in commit author/committer parsing, high). python-semantic-release **10.6.1** still reads that attribute on every config load, so the release step died before inspecting a single commit.

0ef07ef works around this with a `sitecustomize.py` shim that re-attaches the regex, loaded via `PYTHONPATH` scoped to the `semantic-release` call. That is the right call *today* — it keeps GitPython current instead of pinning back to the vulnerable 3.1.59, and the re-attached regex only ever sees the configured (trusted) `commit_author`, never repository data.

[python-semantic-release#1477](https://github.com/python-semantic-release/python-semantic-release/pull/1477) drops the read. Once a release carrying it exists, the shim is dead weight — and re-attaching a regex upstream deliberately deleted for a security fix stops being defensible.

## What this changes

- Shim block and its self-test removed from the install step
- `PYTHONPATH` prefix removed from the `semantic-release` invocation
- Install floor raised to `"python-semantic-release>10.6.1"`

Net: **-42 / +2**. The install step returns to its pre-incident shape, plus the floor.

## Why the floor instead of a bare install

It turns a premature merge into an immediate, legible failure. Verified against PyPI on 2026-08-26:

```
ERROR: No matching distribution found for python-semantic-release>10.6.1
```

The job stops at the install step with an obvious message, rather than resolving 10.6.1 and dying later with `type object 'Actor' has no attribute 'name_email_regex'`.

It is a **minimum, not a pin** — GitPython and PSR both stay on their current releases, consistent with the org rule against pinning by default.

## Merge precondition

- [ ] A python-semantic-release release **newer than 10.6.1** exists on PyPI
- [ ] That release no longer references `name_email_regex` (i.e. contains #1477)
- [ ] A dispatch run of a consumer repo's release pipeline is green

Status on 2026-08-26: latest release is **10.6.1** (2026-07-06). #1477 is merged on `main` but unreleased.

## Verification commands

```bash
# 1. Has a newer release shipped?
curl -s https://pypi.org/pypi/python-semantic-release/json | jq -r .info.version

# 2. Is the offending read really gone from it?
pip download --no-deps --no-binary :all: "python-semantic-release>10.6.1" -d /tmp/psr
grep -r name_email_regex /tmp/psr   # expect: no matches

# 3. Prove it end-to-end before merging
gh workflow run python-automatic-release.yml --repo bauer-group/XPD-AIModelSync --ref main
```

Note that `gh run rerun` will **not** exercise a change to this file — a re-run replays the reusable-workflow version resolved when the original run started. Use a fresh dispatch or push.

## Conflict risk

This branch touches `.github/workflows/python-semantic-release.yml`, which PRs #68 and #71 may also touch. If either lands first, rebase this branch before merging.
